### PR TITLE
修复参数解构调用时与 @babel/plugin-transform-spread 存在冲突的问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,7 @@ _get()
 ```
 
 For more examples, please see the catalog test
+
+## Limitations
+- Chain sequences aren’t supported.
+- Destructuring assignment aren’t supported.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elfin-fe/babel-plugin-glodash",
-  "version": "1.0.7",
+  "version": "1.1.0",
   "description": "elfin babel plugin",
   "repository": {
     "type": "git",

--- a/src/index.js
+++ b/src/index.js
@@ -1,32 +1,46 @@
-import {addDefault} from '@babel/helper-module-imports';
+import {addDefault} from '@babel/helper-module-imports'
 
 const CHAIN_ERROR = 'Lodash chain sequences are not supported by babel-plugin-elfin.'
+
+function transformMemberExp(rootPath, path, t) {
+    const {node, scope} = path
+    const objectPath = path.get('object')
+    if (objectPath.isMemberExpression()) {
+        transformMemberExp(rootPath, objectPath, t)
+        return
+    }
+    if (!t.isIdentifier(node.object, {name: 'glodash'})) return
+    const property = node.property
+    // 是否自定义了 glodash 变量
+    if (scope.getBinding('glodash') || !property) return
+    // module标示
+    const propertyName = property.name
+    // 不支持chain的链式调用
+    if (propertyName === 'chain') {
+        throw path.buildCodeFrameError(CHAIN_ERROR)
+    }
+    // 处理参数同名的情况
+    const {name} = addDefault(rootPath, `lodash/${propertyName}`, {nameHint: propertyName})
+    path.replaceWith(t.identifier(name))
+}
 
 export default function (babel) {
     const {types: t} = babel;
     return {
         name: 'elfin-glodash',
         visitor: {
-            MemberExpression: {
-                exit(path) {
-                    if (!path.hub) return
-                    const {file} = path.hub
-                    const {node} = path
-                    // 是以属性调用的形式使用 glodash.cloneDeep()
-                    if (!t.isIdentifier(path.node.object, {name: 'glodash'})) return
-                    const property = node.property
-                    // 是否自定义了 glodash 变量
-                    if (file.scope.getBinding('glodash') || !property) return
-                    // module标示
-                    const propertyName = property.name
-                    // 不支持chain的链式调用
-                    if (propertyName === 'chain') {
-                        throw path.buildCodeFrameError(CHAIN_ERROR)
-                    }
-                    // 处理参数同名的情况
-                    const {name} = addDefault(path, `lodash/${propertyName}`, {nameHint: propertyName})
-                    path.replaceWith(t.identifier(name))
-                },
+            CallExpression(path) {
+                const calleePath = path.get('callee')
+                if (calleePath.isMemberExpression()) {
+                    transformMemberExp(path, calleePath, t)
+                }
+            },
+            VariableDeclarator(path) {
+                const initPath = path.get('init')
+                if (initPath.isMemberExpression()) {
+                    transformMemberExp(path, initPath, t)
+                }
+                // TODO: Destructuring assignment support
             },
         }
     };

--- a/test/fixtures/arguments-destructuring/actual.js
+++ b/test/fixtures/arguments-destructuring/actual.js
@@ -1,0 +1,2 @@
+const a = [[1], [1, 2]]
+glodash.union(...a)

--- a/test/fixtures/arguments-destructuring/expected.js
+++ b/test/fixtures/arguments-destructuring/expected.js
@@ -1,0 +1,9 @@
+"use strict";
+
+var _union2 = _interopRequireDefault(require("lodash/union"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
+
+var a = [[1], [1, 2]];
+
+_union2["default"].apply(void 0, a);

--- a/test/fixtures/assignment-statement/actual.js
+++ b/test/fixtures/assignment-statement/actual.js
@@ -1,0 +1,4 @@
+const a = {}
+
+const get = glodash.get
+get(a, 'a')

--- a/test/fixtures/assignment-statement/expected.js
+++ b/test/fixtures/assignment-statement/expected.js
@@ -1,0 +1,9 @@
+"use strict";
+
+var _get2 = _interopRequireDefault(require("lodash/get"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
+
+var a = {};
+var get = _get2["default"];
+get(a, 'a');


### PR DESCRIPTION
`@babel/plugin-transform-spread` 会在 `CallExpression` visitor 中将
```js
glodash.intersectionBy(...a)
```
转换成
```js
var _glodash;

(_glodash = glodash).intersectionBy.apply(_glodash, a);
```

导致当前实现的依赖的下级 `MemberExpression` 节点丢失从而失效